### PR TITLE
Adds files indexing that were fixed by php-cs-fixer before commit creating

### DIFF
--- a/src/pre-commit/php_cs_fixer.sh
+++ b/src/pre-commit/php_cs_fixer.sh
@@ -8,3 +8,5 @@ then
 fi
 
 vendor/bin/php-cs-fixer fix --diff
+
+git add --all


### PR DESCRIPTION
Hey, @greeflas!
I added improvements for /src/pre-commit/php_cs_fixer.sh namely the indexing of files that were fixed so that these files were immediately added to the commit. Please, check.